### PR TITLE
fix: remove unregistered ar_markers dependency (dependency confusion)

### DIFF
--- a/apps/hand_tracking/requirements.txt
+++ b/apps/hand_tracking/requirements.txt
@@ -1,3 +1,2 @@
-ar_markers
 pyrealsense2
 transforms3d


### PR DESCRIPTION
`ar_markers` in `apps/hand_tracking/requirements.txt` is not a registered PyPI package. A bare `pip install -r requirements.txt` queries PyPI for it; an attacker who registers the name at any version would have their package installed in the hand tracking environment.

This PR removes `ar_markers` from the requirements file.
